### PR TITLE
breaking change! add `callable` type-hints.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
 matrix:
   allow_failures:
     - php: hhvm
@@ -16,4 +18,4 @@ before_script:
   - composer install --dev --prefer-source
 
 script:
-  - ./vendor/bin/phpunit
+  - ./vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
         {
             "name": "Tim Klever",
             "email": "tim.klever@webpt.com"
+        },
+        {
+            "name": "Timothy Younger",
+            "email": "tim@webpt.com"
         }
     ],
     "autoload": {
@@ -13,10 +17,10 @@
         }
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": "^7.0|^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0"
+        "phpunit/phpunit": "^5.0|^4.8"
     },
     "extra": {
         "branch-alias": {

--- a/src/Aquaduck/Aquaduck.php
+++ b/src/Aquaduck/Aquaduck.php
@@ -2,36 +2,40 @@
 
 namespace Webpt\Aquaduck;
 
-use Webpt\Aquaduck\Exception\InvalidArgumentException;
 use SplPriorityQueue;
 use Webpt\Aquaduck\Middleware\MiddlewareInterface;
 
 class Aquaduck implements MiddlewareInterface, PriorityBindableInterface
 {
     private $serial = PHP_INT_MAX;
+    
+    /** @var SplPriorityQueue */
+    private $queue;
 
     public function __construct()
     {
         $this->queue = new SplPriorityQueue();
     }
 
-    public function __invoke($subject, $out = null)
+    /**
+     * @param mixed $subject
+     * @param callable $out
+     * @return mixed
+     */
+    public function __invoke($subject, callable $out = null)
     {
-        if ($out !== null && !is_callable($out)) {
-            throw new InvalidArgumentException('Final Handler must be callable');
-        }
-
         $done   = $out ?: new FinalHandler();
         $next   = new Next($this->queue, $done, new Handler);
         return $next($subject);
     }
 
-    public function bind($middleware, $priority = 1)
+    /**
+     * @param callable $middleware
+     * @param mixed[]|int $priority
+     * @return $this
+     */
+    public function bind(callable $middleware, $priority = 1)
     {
-        if (!is_callable($middleware)) {
-            throw new InvalidArgumentException('Middleware must be callable');
-        }
-
         if (!is_array($priority)) {
             $priority = array($priority, $this->serial--);
         }

--- a/src/Aquaduck/ErrorHandler/ErrorHandlerInterface.php
+++ b/src/Aquaduck/ErrorHandler/ErrorHandlerInterface.php
@@ -4,5 +4,11 @@ namespace Webpt\Aquaduck\ErrorHandler;
 
 interface ErrorHandlerInterface
 {
-    public function __invoke($error, $subject, $next = null);
+    /**
+     * @param $error
+     * @param mixed $subject
+     * @param callable $next
+     * @return mixed
+     */
+    public function __invoke($error, $subject, callable $next = null);
 }

--- a/src/Aquaduck/FinalHandler.php
+++ b/src/Aquaduck/FinalHandler.php
@@ -10,20 +10,37 @@ class FinalHandler
     private $errorMessage;
     private $errorCode;
 
+    /**
+     * FinalHandler constructor.
+     * @param string $errorMessage
+     * @param int $errorCode
+     */
     public function __construct($errorMessage = "Unknown Error", $errorCode = 0)
     {
         $this->errorMessage = $errorMessage;
         $this->errorCode    = $errorCode;
     }
 
+    /**
+     * @param mixed $subject
+     * @param \Exception|string $err
+     * @return mixed|null
+     * @throws \Webpt\Aquaduck\Exception\RuntimeException
+     */
     public function __invoke($subject, $err = null)
     {
         if ($err) {
-            return $this->handleError($err, $subject);
+            $this->handleError($err);
+            return null;
         }
         return $subject;
     }
 
+    /**
+     * @param \Exception|string $err
+     * @return void
+     * @throws \Webpt\Aquaduck\Exception\RuntimeException
+     */
     private function handleError($err)
     {
         $message = $this->errorMessage;

--- a/src/Aquaduck/Handler.php
+++ b/src/Aquaduck/Handler.php
@@ -4,24 +4,22 @@ namespace Webpt\Aquaduck;
 
 use Exception;
 use Webpt\Aquaduck\ErrorHandler\ErrorHandlerUtility;
-use Webpt\Aquaduck\Exception\InvalidArgumentException;
 
 class Handler implements HandlerInterface
 {
+    /**
+     * @param callable $middleware
+     * @param mixed $subject
+     * @param mixed $err
+     * @param callable $next
+     * @return mixed
+     */
     public function __invoke(
-        $middleware,
+        callable $middleware,
         $subject,
         $err,
-        $next
+        callable $next
     ) {
-        if (!is_callable($middleware)) {
-            throw new InvalidArgumentException('$middleware must be callable');
-        }
-
-        if (!is_callable($next)) {
-            throw new InvalidArgumentException('$next must be callable');
-        }
-
         $hasError = (null !== $err);
         $isErrorHandler = ErrorHandlerUtility::isErrorHandler($middleware);
 

--- a/src/Aquaduck/HandlerInterface.php
+++ b/src/Aquaduck/HandlerInterface.php
@@ -4,5 +4,12 @@ namespace Webpt\Aquaduck;
 
 interface HandlerInterface
 {
-    public function __invoke($middleware, $subject, $err, $next);
+    /**
+     * @param callable $middleware
+     * @param mixed $subject
+     * @param mixed $err
+     * @param callable $next
+     * @return mixed
+     */
+    public function __invoke(callable $middleware, $subject, $err, callable $next);
 }

--- a/src/Aquaduck/Middleware/AbstractMiddleware.php
+++ b/src/Aquaduck/Middleware/AbstractMiddleware.php
@@ -2,8 +2,6 @@
 
 namespace Webpt\Aquaduck\Middleware;
 
-use Webpt\Aquaduck\Exception\InvalidArgumentException;
-
 abstract class AbstractMiddleware implements MiddlewareInterface
 {
     const ORDER_PREPEND = 'prepend';
@@ -19,36 +17,45 @@ abstract class AbstractMiddleware implements MiddlewareInterface
         return $this->order;
     }
 
+    /**
+     * @return bool
+     */
     public function isPrepend()
     {
         return ($this->getOrder() === static::ORDER_PREPEND);
     }
 
+    /**
+     * @return bool
+     */
     public function isAppend()
     {
         return ($this->getOrder() === static::ORDER_APPEND);
     }
 
-    public function __invoke($subject, $next = null)
+    /**
+     * @param mixed $subject
+     * @param callable $next
+     * @return mixed
+     */
+    public function __invoke($subject, callable $next = null)
     {
-        if ($next && !is_callable($next)) {
-            throw new InvalidArgumentException(
-                sprintf('Second parameter must be a valid callback or null; received "%s"', gettype($next))
-            );
-        }
-
-        if ($this->isPrepend() && $next) {
+        if ($next && $this->isPrepend()) {
             $subject = $next($subject);
         }
 
         $transformed = $this->execute($subject);
 
-        if ($this->isAppend() && $next) {
+        if ($next && $this->isAppend()) {
             return $next($transformed);
         }
 
         return $transformed;
     }
 
+    /**
+     * @param mixed $subject
+     * @return mixed
+     */
     abstract protected function execute($subject);
 }

--- a/src/Aquaduck/Middleware/MiddlewareInterface.php
+++ b/src/Aquaduck/Middleware/MiddlewareInterface.php
@@ -4,5 +4,10 @@ namespace Webpt\Aquaduck\Middleware;
 
 interface MiddlewareInterface
 {
-    public function __invoke($subject, $next = null);
+    /**
+     * @param mixed $subject
+     * @param callable $next
+     * @return mixed
+     */
+    public function __invoke($subject, callable $next = null);
 }

--- a/src/Aquaduck/Next.php
+++ b/src/Aquaduck/Next.php
@@ -3,19 +3,20 @@
 namespace Webpt\Aquaduck;
 
 use SplPriorityQueue;
-use Webpt\Aquaduck\Exception\InvalidArgumentException;
 
 class Next
 {
     private $queue;
     private $done;
 
-    public function __construct(SplPriorityQueue $queue, $done, $handler = null)
+    /**
+     * Next constructor.
+     * @param SplPriorityQueue $queue
+     * @param callable $done
+     * @param callable $handler
+     */
+    public function __construct(SplPriorityQueue $queue, callable $done, callable $handler = null)
     {
-        if (!is_callable($done)) {
-            throw new InvalidArgumentException('2nd constructor argument must be callable');
-        }
-
         $this->queue   = clone $queue;
         $this->done    = $done;
         $this->handler = $handler ?: new Handler();

--- a/src/Aquaduck/PriorityBindableInterface.php
+++ b/src/Aquaduck/PriorityBindableInterface.php
@@ -2,11 +2,14 @@
 
 namespace Webpt\Aquaduck;
 
+use Webpt\Aquaduck\ErrorHandler\ErrorHandlerInterface;
+use Webpt\Aquaduck\Middleware\MiddlewareInterface;
+
 interface PriorityBindableInterface
 {
     /**
-     * @param ErrorHandler\ErrorHandlerInterface|MiddlewareInterface|callable $middleware
+     * @param ErrorHandlerInterface|MiddlewareInterface|callable $middleware
      * @param int $priority
      */
-    public function bind($middleware, $priority = 1);
+    public function bind(callable $middleware, $priority = 1);
 }

--- a/test/AquaduckTest/AquaduckTest.php
+++ b/test/AquaduckTest/AquaduckTest.php
@@ -16,19 +16,25 @@ class AquaduckTest extends \PHPUnit_Framework_TestCase
         $this->aquaduck = new Aquaduck();
     }
 
-    /**
-     * @expectedException \Webpt\Aquaduck\Exception\InvalidArgumentException
-     */
     public function testThrowExceptionOnInvalidMiddleware()
     {
+        if (phpversion() < '7.0') {
+            $this->setExpectedException('\PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('\TypeError');
+        }
+        
         $this->aquaduck->bind('totally-invalid-argument');
     }
 
-    /**
-     * @expectedException \Webpt\Aquaduck\Exception\InvalidArgumentException
-     */
     public function testThrowExceptionOnInvalidFinalHandler()
     {
+        if (phpversion() < '7.0') {
+            $this->setExpectedException('\PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('\TypeError');
+        }
+
         $aquaduck = $this->aquaduck;
         $aquaduck(1, 'totally-invalid-argument');
     }

--- a/test/AquaduckTest/HandlerTest.php
+++ b/test/AquaduckTest/HandlerTest.php
@@ -16,20 +16,26 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
         $this->handler = new Handler();
     }
 
-    /**
-     * @expectedException \Webpt\Aquaduck\Exception\InvalidArgumentException
-     */
     public function testThrowExceptionOnInvalidMiddlewareCallback()
     {
+        if (phpversion() < '7.0') {
+            $this->setExpectedException('\PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('\TypeError');
+        }
+
         $handler = $this->handler;
         $handler('totally-invalid-argument', 1, null, function() {});
     }
 
-    /**
-     * @expectedException \Webpt\Aquaduck\Exception\InvalidArgumentException
-     */
     public function testThrowExceptionOnInvalidNextCallback()
     {
+        if (phpversion() < '7.0') {
+            $this->setExpectedException('\PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('\TypeError');
+        }
+
         $handler = $this->handler;
         $handler(function() {}, 1, null, 'totally-invalid-argument');
     }

--- a/test/AquaduckTest/Middleware/AbstractMiddlewareTest.php
+++ b/test/AquaduckTest/Middleware/AbstractMiddlewareTest.php
@@ -52,11 +52,14 @@ class AbstractMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertContains(4, $result);
     }
 
-    /**
-     * @expectedException \Webpt\Aquaduck\Exception\InvalidArgumentException
-     */
     public function testThrowsExceptionOnInvalidCallback()
     {
+        if (phpversion() < '7.0') {
+            $this->setExpectedException('\PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('\TypeError');
+        }
+
         $middleware = $this->middleware;
         $middleware(array(), 'INVALID-CALLBACK');
     }

--- a/test/AquaduckTest/NextTest.php
+++ b/test/AquaduckTest/NextTest.php
@@ -20,11 +20,14 @@ class NextTest extends \PHPUnit_Framework_TestCase
         return call_user_func($callback, $subject, $error);
     }
 
-    /**
-     * @expectedException \Webpt\Aquaduck\Exception\InvalidArgumentException
-     */
     public function testThrowsExceptionOnInvalidDoneCallback()
     {
+        if (phpversion() < '7.0') {
+            $this->setExpectedException('\PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('\TypeError');
+        }
+
         new Next(new SplPriorityQueue(), 'INVALID CALLBACK');
     }
 


### PR DESCRIPTION
require php54 or greater. add `callable` type-hints where applicable (breaking change!) to reduce the number of custom type-check branches.
